### PR TITLE
Remove textarea extra elements

### DIFF
--- a/src/component/cursors.vue
+++ b/src/component/cursors.vue
@@ -2,7 +2,7 @@
   <canvas ref="overlay" class="neko-cursors" tabindex="0" />
 </template>
 
-<style lang="scss" scoped>
+<style lang="scss">
   .neko-cursors {
     position: absolute;
     top: 0;

--- a/src/component/main.vue
+++ b/src/component/main.vue
@@ -43,7 +43,7 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
+<style lang="scss">
   .neko-component {
     width: 100%;
     height: 100%;

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="neko-overlay-wrap">
     <canvas ref="overlay" class="neko-overlay" tabindex="0" />
     <textarea
       ref="textarea"
@@ -22,7 +22,12 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
+<style lang="scss">
+  /* hide elements around textarea if added by browsers extensions */
+  .neko-overlay-wrap *:not(.neko-overlay) {
+    display: none;
+  }
+
   .neko-overlay {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Hide additional elements around textarea, that could have been added by various browsers extensions (e.g. Gramarly).