### PR TITLE
Robust websocket close event handling

### DIFF
--- a/src/component/internal/connection.ts
+++ b/src/component/internal/connection.ts
@@ -201,18 +201,19 @@ export class NekoConnection extends EventEmitter<NekoConnectionEvents> {
 
   public close(error?: Error) {
     if (this._open) {
-      this._open = false
-
       // set state to disconnected
       Vue.set(this._state.websocket, 'connected', false)
       Vue.set(this._state.webrtc, 'connected', false)
       Vue.set(this._state, 'status', 'disconnected')
-
-      this.emit('close', error)
     }
 
     // close all reconnectors
     Object.values(this._reconnector).forEach((r) => r.close())
+
+    if (this._open) {
+      this._open = false
+      this.emit('close', error)
+    }
   }
 
   public destroy() {

--- a/src/component/internal/reconnector/websocket.ts
+++ b/src/component/internal/reconnector/websocket.ts
@@ -30,7 +30,7 @@ export class WebsocketReconnector extends ReconnectorAbstract {
     if (!this._websocket.supported) return
 
     if (this._websocket.connected) {
-      this._websocket.disconnect()
+      this._websocket.disconnect('connection replaced')
     }
 
     let url = this._state.url
@@ -45,7 +45,7 @@ export class WebsocketReconnector extends ReconnectorAbstract {
   }
 
   public disconnect() {
-    this._websocket.disconnect()
+    this._websocket.disconnect('manual disconnect')
   }
 
   public destroy() {

--- a/src/component/main.vue
+++ b/src/component/main.vue
@@ -20,7 +20,7 @@
         :cursorDraw="inactiveCursorDrawFunction"
       />
       <neko-overlay
-        v-show="!private_mode_enabled && connected"
+        v-show="!private_mode_enabled && state.connection.status != 'disconnected'"
         :style="{ pointerEvents: state.control.locked ? 'none' : 'auto' }"
         :wsControl="control"
         :sessions="state.sessions"


### PR DESCRIPTION
Currently when WebSocket is closed, we don't know the reason. This change adds better insights to logs why reconnect happened and makes its handling more robust in general.