### PR TITLE
Fix stereo for chromium

### DIFF
--- a/src/component/internal/webrtc.ts
+++ b/src/component/internal/webrtc.ts
@@ -233,6 +233,10 @@ export class NekoWebRTC extends EventEmitter<NekoWebRTCEvents> {
     }
 
     const answer = await this._peer.createAnswer()
+
+    // add stereo=1 to answer sdp to enable stereo audio for chromium
+    answer.sdp = answer.sdp?.replace(/(stereo=1;)?useinbandfec=1/, 'useinbandfec=1;stereo=1')
+
     this._peer.setLocalDescription(answer)
 
     if (answer) {


### PR DESCRIPTION
Chromium has been downmixing stereo to mono. Adding `stereo=1` to SDP after creating answer and before setting it as local description fixes this issue.
https://bugs.chromium.org/p/webrtc/issues/detail?id=8649