### PR TITLE
Add mobile keyboard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ echo \"@demodesk:registry\" \"https://npm.pkg.github.com\" >> .yarnrc
 You can set keyboard provider at build time, either `novnc` or the default `guacamole`.
 
 ```bash
-# by default uses guacamole keybaord
+# by default uses guacamole keyboard
 npm run build
-# uses novnc keybaord
+# uses novnc keyboard
 KEYBOARD=novnc npm run build
 ```
 

--- a/src/component/main.vue
+++ b/src/component/main.vue
@@ -36,6 +36,7 @@
         :inactiveCursors="state.settings.inactive_cursors && session.profile.sends_inactive_cursor"
         @updateKeyboardModifiers="updateKeyboardModifiers($event)"
         @uploadDrop="uploadDrop($event)"
+        @mobileKeyboardOpen="state.mobile_keyboard_open = $event"
       />
     </div>
   </div>
@@ -198,6 +199,7 @@
         merciful_reconnect: false,
       },
       cursors: [],
+      mobile_keyboard_open: false,
     } as NekoState
 
     /////////////////////////////
@@ -362,14 +364,6 @@
       this.connection.close()
     }
 
-    public showMobileKeyboard() {
-      this._overlay.showMobileKeyboard()
-    }
-
-    public hideMobileKeyboard() {
-      this._overlay.hideMobileKeyboard()
-    }
-
     public setReconnectorConfig(type: 'websocket' | 'webrtc', config: ReconnectorConfig) {
       if (type != 'websocket' && type != 'webrtc') {
         throw new Error('unknown reconnector type')
@@ -413,6 +407,22 @@
 
     public setKeyboard(layout: string, variant: string = '') {
       Vue.set(this.state.control, 'keyboard', { layout, variant })
+    }
+
+    public mobileKeyboardShow() {
+      this._overlay.mobileKeyboardShow()
+    }
+
+    public mobileKeyboardHide() {
+      this._overlay.mobileKeyboardHide()
+    }
+
+    public mobileKeyboardToggle() {
+      if (this.state.mobile_keyboard_open) {
+        this.mobileKeyboardHide()
+      } else {
+        this.mobileKeyboardShow()
+      }
     }
 
     public setCursorDrawFunction(fn?: CursorDrawFunction) {

--- a/src/component/main.vue
+++ b/src/component/main.vue
@@ -20,6 +20,7 @@
         :cursorDraw="inactiveCursorDrawFunction"
       />
       <neko-overlay
+        ref="overlay"
         v-show="!private_mode_enabled && state.connection.status != 'disconnected'"
         :style="{ pointerEvents: state.control.locked ? 'none' : 'auto' }"
         :wsControl="control"
@@ -102,6 +103,7 @@
     @Ref('component') readonly _component!: HTMLElement
     @Ref('container') readonly _container!: HTMLElement
     @Ref('video') readonly _video!: HTMLVideoElement
+    @Ref('overlay') readonly _overlay!: Overlay
 
     // fallback image for webrtc reconnections:
     // chrome shows black screen when closing webrtc connection, that's why
@@ -358,6 +360,14 @@
 
     public disconnect() {
       this.connection.close()
+    }
+
+    public showMobileKeyboard() {
+      this._overlay.showMobileKeyboard()
+    }
+
+    public hideMobileKeyboard() {
+      this._overlay.hideMobileKeyboard()
     }
 
     public setReconnectorConfig(type: 'websocket' | 'webrtc', config: ReconnectorConfig) {

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -33,8 +33,9 @@
     bottom: 0;
     width: 100%;
     height: 100%;
-    font-size: 1px; /* chrome would not paste text if 0px */
+    font-size: 16px; /* at least 16px to avoid zooming on mobile */
     resize: none; /* hide textarea resize corner */
+    caret-color: transparent; /* hide caret */
     outline: 0;
     border: 0;
     color: transparent;

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -646,18 +646,20 @@
     public kbdShow = false
     public kbdOpen = false
 
-    public showMobileKeyboard() {
+    public mobileKeyboardShow() {
       this.kbdShow = true
       this.kbdOpen = false
 
       this._textarea.focus()
       window.visualViewport.addEventListener('resize', this.onVisualViewportResize)
+      this.$emit('mobileKeyboardOpen', true)
     }
 
-    public hideMobileKeyboard() {
+    public mobileKeyboardHide() {
       this.kbdShow = false
       this.kbdOpen = false
 
+      this.$emit('mobileKeyboardOpen', false)
       window.visualViewport.removeEventListener('resize', this.onVisualViewportResize)
       this._textarea.blur()
     }
@@ -670,7 +672,7 @@
       if (!this.kbdOpen) {
         this.kbdOpen = true
       } else {
-        this.hideMobileKeyboard()
+        this.mobileKeyboardHide()
       }
     }
   }

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -117,6 +117,10 @@
       return 'url(' + uri + ') ' + x + ' ' + y + ', default'
     }
 
+    get isTouchDevice(): boolean {
+      return 'ontouchstart' in window || navigator.maxTouchPoints > 0
+    }
+
     mounted() {
       // register mouseup globally as user can release mouse button outside of overlay
       window.addEventListener('mouseup', this.onMouseUp, true)
@@ -374,7 +378,11 @@
     }
 
     onMouseEnter(e: MouseEvent) {
-      this._textarea.focus()
+      // focus opens the keyboard on mobile (only for android)
+      if (!this.isTouchDevice) {
+        this._textarea.focus()
+      }
+
       this.focused = true
 
       if (this.isControling) {
@@ -631,12 +639,39 @@
       }
     }
 
+    //
+    // mobile keyboard
+    //
+
+    public kbdShow = false
+    public kbdOpen = false
+
     public showMobileKeyboard() {
+      this.kbdShow = true
+      this.kbdOpen = false
+
       this._textarea.focus()
+      window.visualViewport.addEventListener('resize', this.onVisualViewportResize)
     }
 
     public hideMobileKeyboard() {
+      this.kbdShow = false
+      this.kbdOpen = false
+
+      window.visualViewport.removeEventListener('resize', this.onVisualViewportResize)
       this._textarea.blur()
+    }
+
+    // visual viewport resize event is fired when keyboard is opened or closed
+    // android does not blur textarea when keyboard is closed, so we need to do it manually
+    onVisualViewportResize() {
+      if (!this.kbdShow) return
+
+      if (!this.kbdOpen) {
+        this.kbdOpen = true
+      } else {
+        this.hideMobileKeyboard()
+      }
     }
   }
 </script>

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -647,6 +647,9 @@
     public kbdOpen = false
 
     public mobileKeyboardShow() {
+      // skip if not a touch device
+      if (!this.isTouchDevice) return
+
       this.kbdShow = true
       this.kbdOpen = false
 
@@ -656,6 +659,9 @@
     }
 
     public mobileKeyboardHide() {
+      // skip if not a touch device
+      if (!this.isTouchDevice) return
+
       this.kbdShow = false
       this.kbdOpen = false
 

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -630,5 +630,13 @@
         this.wsControl.release()
       }
     }
+
+    public showMobileKeyboard() {
+      this._textarea.focus()
+    }
+
+    public hideMobileKeyboard() {
+      this._textarea.blur()
+    }
   }
 </script>

--- a/src/component/types/state.ts
+++ b/src/component/types/state.ts
@@ -11,6 +11,7 @@ export default interface State {
   sessions: Record<string, Session>
   settings: Settings
   cursors: Cursors
+  mobile_keyboard_open: boolean
 }
 
 /////////////////////////////

--- a/src/page/components/events.vue
+++ b/src/page/components/events.vue
@@ -401,6 +401,18 @@
       </tr>
 
       <tr>
+        <th>mobile_keyboard_open</th>
+        <td>
+          <div class="space-between">
+            <span>{{ neko.state.mobile_keyboard_open }}</span>
+            <button title="cut" @click="neko.mobileKeyboardToggle">
+              <i class="fas fa-toggle-on"></i>
+            </button>
+          </div>
+        </td>
+      </tr>
+
+      <tr>
         <th>control actions</th>
         <td>
           <button title="cut" @click="neko.control.cut()"><i class="fas fa-cut" /></button>

--- a/src/page/components/events.vue
+++ b/src/page/components/events.vue
@@ -405,7 +405,7 @@
         <td>
           <div class="space-between">
             <span>{{ neko.state.mobile_keyboard_open }}</span>
-            <button title="cut" @click="neko.mobileKeyboardToggle">
+            <button @click="neko.mobileKeyboardToggle">
               <i class="fas fa-toggle-on"></i>
             </button>
           </div>

--- a/src/page/main.vue
+++ b/src/page/main.vue
@@ -43,7 +43,11 @@
         </div>
       </div>
       <div class="room-container" style="text-align: center">
-        <button v-if="isTouchDevice" @click="showMobileKeyboard" style="position: absolute; left: 5px; transform: translateY(-100%)">
+        <button
+          v-if="isTouchDevice"
+          @click="showMobileKeyboard"
+          style="position: absolute; left: 5px; transform: translateY(-100%)"
+        >
           <i class="fa fa-keyboard" />
         </button>
         <span v-if="loaded && neko.state.session_id" style="padding-top: 10px">

--- a/src/page/main.vue
+++ b/src/page/main.vue
@@ -43,6 +43,9 @@
         </div>
       </div>
       <div class="room-container" style="text-align: center">
+        <button v-if="isTouchDevice" @click="showMobileKeyboard" style="position: absolute; left: 5px; transform: translateY(-100%)">
+          <i class="fa fa-keyboard" />
+        </button>
         <span v-if="loaded && neko.state.session_id" style="padding-top: 10px">
           You are logged in as
           <strong style="font-weight: bold">
@@ -377,6 +380,15 @@
 
     uploadActive = false
     uploadProgress = 0
+
+    get isTouchDevice(): boolean {
+      return 'ontouchstart' in window || navigator.maxTouchPoints > 0
+    }
+
+    showMobileKeyboard() {
+      // @ts-ignore
+      document.querySelector('textarea.neko-overlay').focus()
+    }
 
     dialogOverlayActive = false
     dialogRequestActive = false

--- a/src/page/main.vue
+++ b/src/page/main.vue
@@ -44,8 +44,8 @@
       </div>
       <div class="room-container" style="text-align: center">
         <button
-          v-if="isTouchDevice"
-          @click="showMobileKeyboard"
+          v-if="loaded && isTouchDevice"
+          @click="neko.showMobileKeyboard"
           style="position: absolute; left: 5px; transform: translateY(-100%)"
         >
           <i class="fa fa-keyboard" />
@@ -387,11 +387,6 @@
 
     get isTouchDevice(): boolean {
       return 'ontouchstart' in window || navigator.maxTouchPoints > 0
-    }
-
-    showMobileKeyboard() {
-      // @ts-ignore
-      document.querySelector('textarea.neko-overlay').focus()
     }
 
     dialogOverlayActive = false

--- a/src/page/main.vue
+++ b/src/page/main.vue
@@ -45,7 +45,7 @@
       <div class="room-container" style="text-align: center">
         <button
           v-if="loaded && isTouchDevice"
-          @click="neko.showMobileKeyboard"
+          @click="neko.mobileKeyboardToggle"
           style="position: absolute; left: 5px; transform: translateY(-100%)"
         >
           <i class="fa fa-keyboard" />

--- a/src/page/main.vue
+++ b/src/page/main.vue
@@ -193,6 +193,9 @@
       flex-shrink: 0;
       flex-direction: column;
       display: flex;
+      /* for mobile */
+      overflow-y: hidden;
+      overflow-x: auto;
 
       .room-menu {
         max-width: 100%;
@@ -279,10 +282,14 @@
     }
   }
 
+  /* for mobile */
   @media only screen and (max-width: 600px) {
+    $offset: 38px;
+
     #neko.expanded {
+      /* show only enough of the menu to see the toggle button */
       .neko-main {
-        transform: translateX(calc(-100% + 65px));
+        transform: translateX(calc(-100% + $offset));
         video {
           display: none;
         }
@@ -292,14 +299,14 @@
         top: 0;
         right: 0;
         bottom: 0;
-        left: 65px;
-        width: calc(100% - 65px);
+        left: $offset;
+        width: calc(100% - $offset);
       }
-    }
-  }
-  @media only screen and (max-width: 768px) {
-    #neko .neko-main .room-container {
-      display: none;
+      /* display menu toggle button far right */
+      .header .menu,
+      .header .menu li {
+        margin-right: 2px;
+      }
     }
   }
 </style>
@@ -362,7 +369,7 @@
   })
   export default class extends Vue {
     @Ref('neko') readonly neko!: NekoCanvas
-    expanded: boolean = true
+    expanded: boolean = !window.matchMedia('(max-width: 600px)').matches // default to expanded on bigger screens
     loaded: boolean = false
     tab: string = ''
 


### PR DESCRIPTION
Calling `neko.showMobileKeyboard()` shows keyboard on mobile phones, and `neko.hideMobileKeyboard()` hides it. It needs to be called from some user event (clock, touch) otherwise browsers block it.

While keyboard is open, when tapping on the screen, default menu opens:
![image](https://user-images.githubusercontent.com/7534274/214671567-56acd334-9ea5-4049-bcea-c79fdf95990a.png)

Pasting works as well as expected.