### PR TITLE
Fix reporting connection error

### DIFF
--- a/src/page/main.vue
+++ b/src/page/main.vue
@@ -442,7 +442,7 @@
       })
       this.neko.events.on('connection.closed', (error?: Error) => {
         if (error) {
-          alert('Connection closed with error:' + error.message)
+          alert('Connection closed with error: ' + error.message)
         } else {
           alert('Connection closed without error.')
         }


### PR DESCRIPTION
Ensure that close is not intercepted by any other event. Because if connection is closed with an error, first reconnector that is closed fires close event without  any error.