### PR TITLE
Fix textarea focus for touchscreens with keyboard

### DIFF
--- a/src/component/main.vue
+++ b/src/component/main.vue
@@ -35,6 +35,7 @@
         :cursorDraw="cursorDrawFunction"
         :implicitControl="state.settings.implicit_hosting && session.profile.can_host"
         :inactiveCursors="state.settings.inactive_cursors && session.profile.sends_inactive_cursor"
+        :hasMobileKeyboard="is_touch_device"
         :fps="fps"
         @updateKeyboardModifiers="updateKeyboardModifiers($event)"
         @uploadDrop="uploadDrop($event)"
@@ -138,6 +139,10 @@
     @Prop({ type: Number, default: 0 })
     private readonly fps!: number
 
+    // auto / touch / mouse
+    @Prop({ type: String, default: 'auto' })
+    private readonly inputMode!: String
+
     /////////////////////////////
     // Public state
     /////////////////////////////
@@ -234,6 +239,24 @@
 
     public get private_mode_enabled() {
       return this.state.settings.private_mode && !this.is_admin
+    }
+
+    public get is_touch_device() {
+      if (this.inputMode == 'mouse') {
+        return false
+      }
+      if (this.inputMode == 'touch') {
+        return true
+      }
+
+      return (
+        // we assume that if the device has touch support, it is a mobile device
+        ('ontouchstart' in window || navigator.maxTouchPoints > 0) &&
+        // we also check if the device has a pointer
+        !matchMedia('(pointer:fine)').matches &&
+        // and is capable of hover, then it probably has a mouse
+        !matchMedia('(hover:hover)').matches
+      )
     }
 
     @Watch('private_mode_enabled')

--- a/src/component/main.vue
+++ b/src/component/main.vue
@@ -35,8 +35,8 @@
         :cursorDraw="cursorDrawFunction"
         :implicitControl="state.settings.implicit_hosting && session.profile.can_host"
         :inactiveCursors="state.settings.inactive_cursors && session.profile.sends_inactive_cursor"
-        :hasMobileKeyboard="is_touch_device"
         :fps="fps"
+        :hasMobileKeyboard="is_touch_device"
         @updateKeyboardModifiers="updateKeyboardModifiers($event)"
         @uploadDrop="uploadDrop($event)"
         @mobileKeyboardOpen="state.mobile_keyboard_open = $event"
@@ -242,15 +242,11 @@
     }
 
     public get is_touch_device() {
-      if (this.inputMode == 'mouse') {
-        return false
-      }
-      if (this.inputMode == 'touch') {
-        return true
-      }
+      if (this.inputMode == 'mouse') return false
+      if (this.inputMode == 'touch') return true
 
       return (
-        // we assume that if the device has touch support, it is a mobile device
+        // check if the device has a touch screen
         ('ontouchstart' in window || navigator.maxTouchPoints > 0) &&
         // we also check if the device has a pointer
         !matchMedia('(pointer:fine)').matches &&

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -112,6 +112,9 @@
     @Prop()
     private readonly fps!: number
 
+    @Prop()
+    private readonly hasMobileKeyboard!: boolean
+
     get cursor(): string {
       if (!this.isControling || !this.cursorImage) {
         return 'default'
@@ -119,13 +122,6 @@
 
       const { uri, x, y } = this.cursorImage
       return 'url(' + uri + ') ' + x + ' ' + y + ', default'
-    }
-
-    get hasMobileKeyboard(): boolean {
-      // we assume that if the device has touch support, it is a mobile device
-      return 'ontouchstart' in window && navigator.maxTouchPoints > 0 &&
-        // we also check if the device has a mouse, it is probably a laptop
-        !matchMedia('(pointer:fine)').matches && !matchMedia('(hover:hover)').matches
     }
 
     mounted() {

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -121,8 +121,11 @@
       return 'url(' + uri + ') ' + x + ' ' + y + ', default'
     }
 
-    get isTouchDevice(): boolean {
-      return 'ontouchstart' in window || navigator.maxTouchPoints > 0
+    get hasMobileKeyboard(): boolean {
+      // we assume that if the device has touch support, it is a mobile device
+      return 'ontouchstart' in window && navigator.maxTouchPoints > 0 &&
+        // we also check if the device has a mouse, it is probably a laptop
+        !matchMedia('(pointer:fine)').matches && !matchMedia('(hover:hover)').matches
     }
 
     mounted() {
@@ -386,7 +389,7 @@
 
     onMouseEnter(e: MouseEvent) {
       // focus opens the keyboard on mobile (only for android)
-      if (!this.isTouchDevice) {
+      if (!this.hasMobileKeyboard) {
         this._textarea.focus()
       }
 
@@ -678,7 +681,7 @@
 
     public mobileKeyboardShow() {
       // skip if not a touch device
-      if (!this.isTouchDevice) return
+      if (!this.hasMobileKeyboard) return
 
       this.kbdShow = true
       this.kbdOpen = false
@@ -690,7 +693,7 @@
 
     public mobileKeyboardHide() {
       // skip if not a touch device
-      if (!this.isTouchDevice) return
+      if (!this.hasMobileKeyboard) return
 
       this.kbdShow = false
       this.kbdOpen = false


### PR DESCRIPTION
When the device is touch, it is assumed, that virtual keyboard will be used.

But there are some touchscreens with mouse pointer and keyboard out there (some kind of touch notebooks). They were wrongly categorized to have virtual keyboard and therefore focus events were blocked to textarea what prevented them to write text inside the renderer.

This PR adds `inputMode="[touch | mouse | auto]"` properly. For auto, it now checks if pointer is available and if the user has hover capability. If it does, it is not categorized as touch device.