### PR TITLE
Device pixel ratio fix

### DIFF
--- a/src/component/cursors.vue
+++ b/src/component/cursors.vue
@@ -69,11 +69,35 @@
       const { width, height } = this._overlay.getBoundingClientRect()
       this.canvasResize({ width, height })
 
+      // react to pixel ratio changes
+      this.onPixelRatioChange()
+
       // store last drawing points
       this._last_points = {}
     }
 
-    beforeDestroy() {}
+    beforeDestroy() {
+      // stop pixel ratio change listener
+      if (this.unsubscribePixelRatioChange) {
+        this.unsubscribePixelRatioChange()
+      }
+    }
+
+    private unsubscribePixelRatioChange?: () => void
+    private onPixelRatioChange() {
+      if (this.unsubscribePixelRatioChange) {
+        this.unsubscribePixelRatioChange()
+      }
+
+      const media = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
+      media.addEventListener('change', this.onPixelRatioChange)
+      this.unsubscribePixelRatioChange = () => {
+        media.removeEventListener('change', this.onPixelRatioChange)
+      }
+
+      this.canvasScale = window.devicePixelRatio
+      this.onCanvasSizeChange(this.canvasSize)
+    }
 
     @Watch('canvasSize')
     onCanvasSizeChange({ width, height }: Dimension) {

--- a/src/component/cursors.vue
+++ b/src/component/cursors.vue
@@ -213,7 +213,7 @@
 
     canvasDrawCursor(x: number, y: number, id: string) {
       // get intrinsic dimensions
-      let { width, height } = this.canvasSize
+      const { width, height } = this.canvasSize
       x = Math.round((x / this.screenSize.width) * width)
       y = Math.round((y / this.screenSize.height) * height)
 
@@ -246,7 +246,7 @@
       // reset transformation, X and Y will be 0 again
       this._ctx.setTransform(this.canvasScale, 0, 0, this.canvasScale, 0, 0)
 
-      const { width, height } = this._overlay
+      const { width, height } = this.canvasSize
       this._ctx.clearRect(0, 0, width, height)
     }
   }

--- a/src/component/cursors.vue
+++ b/src/component/cursors.vue
@@ -89,7 +89,7 @@
         this.unsubscribePixelRatioChange()
       }
 
-      const media = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
+      const media = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
       media.addEventListener('change', this.onPixelRatioChange)
       this.unsubscribePixelRatioChange = () => {
         media.removeEventListener('change', this.onPixelRatioChange)

--- a/src/component/main.vue
+++ b/src/component/main.vue
@@ -249,9 +249,9 @@
         // check if the device has a touch screen
         ('ontouchstart' in window || navigator.maxTouchPoints > 0) &&
         // we also check if the device has a pointer
-        !matchMedia('(pointer:fine)').matches &&
+        !window.matchMedia('(pointer:fine)').matches &&
         // and is capable of hover, then it probably has a mouse
-        !matchMedia('(hover:hover)').matches
+        !window.matchMedia('(hover:hover)').matches
       )
     }
 

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -138,6 +138,9 @@
       const { width, height } = this._overlay.getBoundingClientRect()
       this.canvasResize({ width, height })
 
+      // react to pixel ratio changes
+      this.onPixelRatioChange()
+
       let ctrlKey = 0
       let noKeyUp = {} as Record<number, boolean>
 
@@ -209,6 +212,11 @@
 
       // stop inactive cursor interval if exists
       this.clearInactiveCursorInterval()
+
+      // stop pixel ratio change listener
+      if (this.unsubscribePixelRatioChange) {
+        this.unsubscribePixelRatioChange()
+      }
     }
 
     getMousePos(clientX: number, clientY: number) {
@@ -498,6 +506,22 @@
     private cursorLastTime = 0
     private canvasRequestedFrame = false
     private canvasRenderTimeout: number | null = null
+
+    private unsubscribePixelRatioChange?: () => void
+    private onPixelRatioChange() {
+      if (this.unsubscribePixelRatioChange) {
+        this.unsubscribePixelRatioChange()
+      }
+
+      const media = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
+      media.addEventListener('change', this.onPixelRatioChange)
+      this.unsubscribePixelRatioChange = () => {
+        media.removeEventListener('change', this.onPixelRatioChange)
+      }
+
+      this.canvasScale = window.devicePixelRatio
+      this.onCanvasSizeChange(this.canvasSize)
+    }
 
     @Watch('canvasSize')
     onCanvasSizeChange({ width, height }: Dimension) {

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -572,7 +572,7 @@
       if (this.cursorImage.width <= 1 && this.cursorImage.height <= 1) return
 
       // get intrinsic dimensions
-      let { width, height } = this.canvasSize
+      const { width, height } = this.canvasSize
 
       // reset transformation, X and Y will be 0 again
       this._ctx.setTransform(this.canvasScale, 0, 0, this.canvasScale, 0, 0)
@@ -619,7 +619,7 @@
       // reset transformation, X and Y will be 0 again
       this._ctx.setTransform(this.canvasScale, 0, 0, this.canvasScale, 0, 0)
 
-      const { width, height } = this._overlay
+      const { width, height } = this.canvasSize
       this._ctx.clearRect(0, 0, width, height)
     }
 

--- a/src/component/overlay.vue
+++ b/src/component/overlay.vue
@@ -513,7 +513,7 @@
         this.unsubscribePixelRatioChange()
       }
 
-      const media = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
+      const media = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
       media.addEventListener('change', this.onPixelRatioChange)
       this.unsubscribePixelRatioChange = () => {
         media.removeEventListener('change', this.onPixelRatioChange)


### PR DESCRIPTION
When device pixel ratio was less than a zero, canvas was not cleaned properly.

Also if device pixel ratio changed while renderer was running, those changes were not applied.