### PR TITLE
Fix autoconnect and autoplay

### DIFF
--- a/src/component/main.vue
+++ b/src/component/main.vue
@@ -310,11 +310,13 @@
       // save token to state
       Vue.set(this.state.connection, 'token', token)
 
-      if (!this.autologin) return
-      await this.authenticate()
-
-      if (!this.autoconnect) return
-      this.connect()
+      // try to authenticate and connect
+      if (this.autoconnect) {
+        try {
+          await this.authenticate()
+          this.connect()
+        } catch {}
+      }
     }
 
     public async authenticate(token?: string) {


### PR DESCRIPTION
Autoconnect was only called when autologin existed. But they should be separated:
- `autologin` - automatically login - saves credentials to local storage.
- `autoconnect`  - automatically connects - only if user is already logged in, if not does nothing.

Autoplay always muted video and then played. But if user allows autoplays it should autoplay with audio. If not, it should play muted and when user clicks anywhere (even inside renderer) it should unmute and remove those listeners, so that it does not accidentaly unmute when user explicitly muted it.