### PR TITLE
Fix WebRTC close issues

### DIFF
--- a/src/component/internal/webrtc.ts
+++ b/src/component/internal/webrtc.ts
@@ -251,7 +251,7 @@ export class NekoWebRTC extends EventEmitter<NekoWebRTCEvents> {
     // add stereo=1 to answer sdp to enable stereo audio for chromium
     answer.sdp = answer.sdp?.replace(/(stereo=1;)?useinbandfec=1/, 'useinbandfec=1;stereo=1')
 
-    this._peer.setLocalDescription(answer)
+    await this._peer.setLocalDescription(answer)
 
     if (answer) {
       this.emit('negotiation', answer)

--- a/src/component/internal/webrtc.ts
+++ b/src/component/internal/webrtc.ts
@@ -281,7 +281,7 @@ export class NekoWebRTC extends EventEmitter<NekoWebRTCEvents> {
       this._log.warn(`unable to generate video snap`, { error })
     }
 
-    this._peer.close()
+    this.onDisconnected(new Error('connection closed'))
   }
 
   public addTrack(track: MediaStreamTrack, ...streams: MediaStream[]): RTCRtpSender {

--- a/src/component/internal/webrtc.ts
+++ b/src/component/internal/webrtc.ts
@@ -238,11 +238,17 @@ export class NekoWebRTC extends EventEmitter<NekoWebRTCEvents> {
     await this._peer.setRemoteDescription({ type: 'offer', sdp })
 
     if (this._candidates.length > 0) {
+      let candidates = 0
       for (const candidate of this._candidates) {
-        await this._peer.addIceCandidate(candidate)
+        try {
+          await this._peer.addIceCandidate(candidate)
+          candidates++
+        } catch (error: any) {
+          this._log.warn(`unable to add remote ICE candidate`, { error })
+        }
       }
 
-      this._log.debug(`added ${this._candidates.length} remote ICE candidates`, { candidates: this._candidates })
+      this._log.debug(`added ${candidates} remote ICE candidates`, { candidates: this._candidates })
       this._candidates = []
     }
 


### PR DESCRIPTION
Server typically sends candidates as soon as they are available. When server uses ICE Lite, those candidates are available instantly, even before the offer is ready. So they might be sent before offer is sent to the client in `signal/provide`. Client gathers such candidates and applies them to the connectian after it receives the offer.

However, in a situation when connection failed on the server before it was even established on the client, server sends `signal/close` that closed the connection. It relied on WebRTC to signal to the rest of the code, that the connection has been closed. But since it was never connected, this event was not fired. That left the users connection in closed state without notifying the rest of the system.

In this case, when reconnection was requested, and the candidates came before `signal/provide`, they would be applied to the old, closed connection that would result in error `Failed to execute 'addIceCandidate' on 'RTCPeerConnection': The RTCPeerConnection's signalingState is 'closed'.`.

Instead of relying on peer's `close()` function, we are discarding whole connection as if it would be signalizes by WebRTC.

Additionally, if any candidate would fail when setting offer (if the candidates were from some ignored previous offer), it would exit the whole function. This error should not be fatal, as shown in [w3c's Perfect Negotiation Example](https://w3c.github.io/webrtc-pc/#perfect-negotiation-example) .