### PR TITLE
Disable pointer events when session can not control

### DIFF
--- a/src/component/main.vue
+++ b/src/component/main.vue
@@ -23,7 +23,7 @@
       <neko-overlay
         ref="overlay"
         v-show="!private_mode_enabled && state.connection.status != 'disconnected'"
-        :style="{ pointerEvents: state.control.locked ? 'none' : 'auto' }"
+        :style="{ pointerEvents: state.control.locked || (session && !session.profile.can_host) ? 'none' : 'auto' }"
         :control="control"
         :sessions="state.sessions"
         :hostId="state.control.host_id"


### PR DESCRIPTION
When user can not control, no pointer/touch events should be prevented or intercepted. Allows zooming in on mobile.